### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/SebastianMartens/Xr18OscPlugin/security/code-scanning/1](https://github.com/SebastianMartens/Xr18OscPlugin/security/code-scanning/1)

In general, fix this by explicitly defining `permissions:` for the workflow or job so that the `GITHUB_TOKEN` has only the privileges required. For a simple CI workflow that just checks out code, restores dependencies, builds, and runs tests, `contents: read` is sufficient.

The best way to fix this without changing functionality is to add a workflow-level `permissions:` block that applies to all jobs. Place it right after the `on:` block (before `jobs:`) in `.github/workflows/dotnet.yml`. Set `contents: read`, which is enough for `actions/checkout@v4` to fetch repository contents; the remaining steps (`dotnet restore`, `dotnet build`, `dotnet test`) don’t need any `GITHUB_TOKEN` privileges.

No additional methods, imports, or definitions are needed since this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
