### PR TITLE
Fix logic bugs, update namespaces, and add global.json for SDK

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.203",
+    "rollForward": "latestPatch"
+  }
+}

--- a/src/Actions/ChannelVolumeAdjustment.cs
+++ b/src/Actions/ChannelVolumeAdjustment.cs
@@ -54,9 +54,9 @@ public class ChannelVolumeAdjustment : PluginDynamicAdjustment
         {
             lrParam.ResetDisplayName = $"Mute Main LR";
         }
-        mainLrBus.Name.ValueChanged += (s, e) => AdjustmentValueChanged("lr");
-        mainLrBus.IsOn.ValueChanged += (s, e) => AdjustmentValueChanged("lr");
-        mainLrBus.MainFaderLevel.ValueChanged += (s, e) => AdjustmentValueChanged("lr");
+        mainLrBus?.Name.ValueChanged += (s, e) => AdjustmentValueChanged("lr");
+        mainLrBus?.IsOn.ValueChanged += (s, e) => AdjustmentValueChanged("lr");
+        mainLrBus?.MainFaderLevel.ValueChanged += (s, e) => AdjustmentValueChanged("lr");
     }
 
     protected override void ApplyAdjustment(string actionParameter, int diff)
@@ -123,7 +123,7 @@ public class ChannelVolumeAdjustment : PluginDynamicAdjustment
     protected override string GetAdjustmentValue(string actionParameter)
     {
         if (actionParameter == "lr")
-            return Xr18OscPlugin.Mixer.MainLrBus.IsOn.Value ? LevelConversions.FormatLevel(Xr18OscPlugin.Mixer.MainLrBus.MainFaderLevel.Value) : "MUTE";
+            return Xr18OscPlugin.Mixer.MainLrBus?.IsOn.Value ?? false ? LevelConversions.FormatLevel(Xr18OscPlugin.Mixer.MainLrBus?.MainFaderLevel.Value ?? 0) : "MUTE";
 
         if (actionParameter.StartsWith("Fx"))
         {
@@ -151,7 +151,7 @@ public class ChannelVolumeAdjustment : PluginDynamicAdjustment
             return channel.Name.Value ?? string.Empty;
 
         if (actionParameter == "lr")
-            return Xr18OscPlugin.Mixer.MainLrBus.Name.Value ?? string.Empty;       
+            return Xr18OscPlugin.Mixer.MainLrBus?.Name.Value ?? string.Empty;       
 
         return actionParameter;
     }

--- a/src/Actions/Connect.cs
+++ b/src/Actions/Connect.cs
@@ -22,7 +22,7 @@ internal class ConnectCommand: ActionEditorCommand
 
     protected override bool RunCommand(ActionEditorActionParameters actionParameters)
     {        
-        if (!actionParameters.TryGetString("sender_ip", out var sender_ip))
+        if (actionParameters.TryGetString("sender_ip", out var sender_ip))
         {
             Xr18OscPlugin.Mixer.OscRemoteIpAddress = sender_ip;
         }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,5 +3,6 @@
         <LangVersion>latest</LangVersion>
         <BaseIntermediateOutputPath>$(SolutionDir)obj\</BaseIntermediateOutputPath>
         <BaseOutputPath>$(SolutionDir)..\bin\</BaseOutputPath>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 </Project>

--- a/src/Domain/AuxBus.cs
+++ b/src/Domain/AuxBus.cs
@@ -1,7 +1,5 @@
 namespace Loupedeck.Xr18OscPlugin.Domain;
 
-using global::Xr18OscPlugin.Domain;
-
 /// <summary>
 /// Represents a single auxiliary bus (XR18: monitor bus 1..6) on the mixer.
 /// </summary>

--- a/src/Domain/Channel.cs
+++ b/src/Domain/Channel.cs
@@ -1,7 +1,5 @@
 namespace Loupedeck.Xr18OscPlugin.Domain;
 
-using global::Xr18OscPlugin.Domain;
-
 /// <summary>
 /// Represents a single channel on the mixer. 
 /// For XR18 these are channels 1-18 and the 4 fx return channels.

--- a/src/Domain/FxChannel.cs
+++ b/src/Domain/FxChannel.cs
@@ -1,7 +1,5 @@
 namespace Loupedeck.Xr18OscPlugin.Domain;
 
-using global::Xr18OscPlugin.Domain;
-
 /// <summary>
 /// Represents a single FX return channel on the mixer. 
 /// 

--- a/src/Domain/IChannelBase.cs
+++ b/src/Domain/IChannelBase.cs
@@ -1,7 +1,5 @@
 namespace Loupedeck.Xr18OscPlugin.Domain;
 
-using global::Xr18OscPlugin.Domain;
-
 /// <summary>
 /// Some features are common for different types of objects on the mixer (e.g. input channels and fx return channels both have main fader levels).
 /// </summary>

--- a/src/Domain/IOscClient.cs
+++ b/src/Domain/IOscClient.cs
@@ -10,7 +10,7 @@ using SharpOSC;
 /// </summary>
 public interface IOscClient
 {
-    void RegisterHandler(string address, EventHandler<OscMessage> messageHandler);
+    Task RegisterHandler(string address, EventHandler<OscMessage> messageHandler);
 
     void Send(string address, object? value = null);
 

--- a/src/Domain/MainLrBus.cs
+++ b/src/Domain/MainLrBus.cs
@@ -1,7 +1,5 @@
 namespace Loupedeck.Xr18OscPlugin.Domain;
 
-using global::Xr18OscPlugin.Domain;
-
 /// <summary>
 /// Represents the Main LR channel on the mixer.
 /// </summary>

--- a/src/Domain/Mixer.cs
+++ b/src/Domain/Mixer.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
 using Loupedeck.Xr18OscPlugin;
+
 using SharpOSC;
 
 /// <summary>
@@ -25,7 +26,7 @@ public class Mixer: IOscClient
 
     public string FirmwareVersion { get; private set; } = "Unknown Version";
 
-    public MainLrBus MainLrBus { get; }
+    public MainLrBus? MainLrBus { get; private set; }
 
     /// <summary>
     /// Channels represent channel strips (level, compressor, pan, eq etc.) for input channels strips.
@@ -54,12 +55,12 @@ public class Mixer: IOscClient
     /// </summary>
     public const int BusCount = 6;
 
-    public Mixer()
+    internal async Task Initialize() 
     {
-        PluginLog.Info("Initializing Mixer domain object...");
-        InitConnection().Wait();
+        PluginLog.Info("Initializing Mixer domain object...");        
+        await InitConnection().ConfigureAwait(false);
 
-        MainLrBus = new MainLrBus(this);        
+        MainLrBus = new MainLrBus(this);
                 
         // CR18: Create regular channels 1-16
         // Channels 17/18 are Line Inputs and usually used for USB return but can be 
@@ -82,6 +83,8 @@ public class Mixer: IOscClient
             FxChannels.Add(new FxChannel(this, fxIndex));
         }        
     }
+
+
 
     #region connection Plugin <=> Mixer
 
@@ -204,7 +207,7 @@ public class Mixer: IOscClient
         catch (OperationCanceledException)
         {
             PluginLog.Info("Mixer discovery timed out.");
-            IsConnectedChanged?.Invoke(this, true); // we only fire on failure. Success events will be triggered by the keep-alive ping.
+            IsConnectedChanged?.Invoke(this, false); // we only fire on failure. Success events will be triggered by the keep-alive ping.
             return false;
         }
         catch (Exception e)
@@ -246,23 +249,17 @@ public class Mixer: IOscClient
 
     private readonly ConcurrentDictionary<string, EventHandler<OscMessage>> _messageHandlers = new();
 
-    public void RegisterHandler(string address, EventHandler<OscMessage> messageHandler)
+    public async Task RegisterHandler(string address, EventHandler<OscMessage> messageHandler)
     {
          _messageHandlers.AddOrUpdate(address, messageHandler, (key, existing) => existing + messageHandler);
         
         // send empty message to trigger mixer to send us the current value for this address.        
         if (IsConnected)
         {
-            Task.Delay(10).Wait(); // wait a bit. The message handler sometimes is not executed otherwise.
+            await Task.Delay(10).ConfigureAwait(false); // wait a bit. The message handler sometimes is not executed otherwise.
             Send(address);
         }
     }
-
-    public void RemoveHandler(string address, EventHandler<OscMessage> messageHandler) =>
-        // Annoyingly, this doesn't actually remove it from the dictionary, even if we end up with a null
-        // value.
-        _messageHandlers.AddOrUpdate(address, messageHandler, (key, existing) => existing - messageHandler ?? existing);
-
 
     private void HandlePacketReceived(IOscPacket packet)
     {        

--- a/src/Domain/SyncedValue.cs
+++ b/src/Domain/SyncedValue.cs
@@ -1,6 +1,5 @@
-namespace Xr18OscPlugin.Domain;
+namespace Loupedeck.Xr18OscPlugin.Domain;
 
-using Loupedeck.Xr18OscPlugin.Domain;
 using SharpOSC;
 
 /// <summary>

--- a/src/Xr18OscPlugin.cs
+++ b/src/Xr18OscPlugin.cs
@@ -22,6 +22,7 @@ public class Xr18OscPlugin : Plugin
         PluginLog.Init(Log);
         PluginResources.Init(Assembly);
         
+        Mixer.Initialize().Wait();
         Mixer.IsConnectedChanged += (sender, isConnected) => UpdateStatus();
     }
 


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes related to null safety, asynchronous operations, and code quality in the mixer domain and related actions. The changes focus on making the codebase more robust by handling potential null references, updating event handling, and enforcing stricter build checks. Additionally, the initialization and connection logic for the mixer has been updated to use asynchronous patterns.

**Null safety and event handling improvements:**

* Added null-conditional checks (`?.`) when subscribing to events and accessing properties of `mainLrBus` in `ChannelVolumeAdjustment.cs` to prevent possible null reference exceptions. [[1]](diffhunk://#diff-64a794095a6b5f35f45ec92f1f5588a77dc419a22261d7c4c301256edd53f076L57-R59) [[2]](diffhunk://#diff-64a794095a6b5f35f45ec92f1f5588a77dc419a22261d7c4c301256edd53f076L126-R126) [[3]](diffhunk://#diff-64a794095a6b5f35f45ec92f1f5588a77dc419a22261d7c4c301256edd53f076L154-R154)
* Changed `MainLrBus` property in `Mixer` from non-nullable to nullable and updated its initialization to occur after an async connection step. [[1]](diffhunk://#diff-9a97ed0393ba9faac76cedf72fa01bc80b77451a4e1f0b44196075ecbe872285L28-R29) [[2]](diffhunk://#diff-9a97ed0393ba9faac76cedf72fa01bc80b77451a4e1f0b44196075ecbe872285L57-R61)

**Asynchronous and connection logic updates:**

* Refactored the `Mixer` class to use an asynchronous `Initialize()` method instead of a synchronous constructor, and updated plugin startup to wait for initialization. [[1]](diffhunk://#diff-9a97ed0393ba9faac76cedf72fa01bc80b77451a4e1f0b44196075ecbe872285L57-R61) [[2]](diffhunk://#diff-7208cf55ae7d3a5a3176426cbebf6879f6d94f474176dae4305c206e57aef914R25)
* Modified `RegisterHandler` in `IOscClient` and `Mixer` to be asynchronous (`Task`-returning), ensuring proper timing when registering OSC message handlers. [[1]](diffhunk://#diff-6db163d1e12edf4617b63eb8d9347e2ddaf19f567a0ae8c25d14b1b43d3e8a23L13-R13) [[2]](diffhunk://#diff-9a97ed0393ba9faac76cedf72fa01bc80b77451a4e1f0b44196075ecbe872285L249-L266)
* Corrected the `IsConnectedChanged` event in `DiscoverMixer()` to fire with `false` on timeout instead of `true`, fixing a logic error.

**Code quality and consistency:**

* Enabled treating all compiler warnings as errors in the build configuration to improve code quality.
* Fixed namespace inconsistencies and removed unnecessary `using` directives in domain model files for clarity and consistency. [[1]](diffhunk://#diff-22141619f03534808a459f09ee099eaa925f0afa8139efb7b85b77ac4c735f41L3-L4) [[2]](diffhunk://#diff-1922f3a01138ea7907c41007ca625031078d9d3b2e65de46bff22a6ba5f8f054L3-L4) [[3]](diffhunk://#diff-d11a2ea8bf6b5ed882acef1cac48afa413386321f40c603fadc23d6e65d5f2b0L3-L4) [[4]](diffhunk://#diff-261a00810c5b32cbf996280974f577dee3f1fbb96d17fc06ab8e7b25d9c07a5fL3-L4) [[5]](diffhunk://#diff-ace724d3790e5b652b13e758307700988c7305111a1b7416d91148d5966e685bL3-L4) [[6]](diffhunk://#diff-5b877be6a008cc30b0ba9f3cc6a06ae8b7a2c412e8d2086e5ee7e3e077d0860dL1-L3)

**Miscellaneous:**

* Added a `global.json` file to specify the .NET SDK version and roll-forward policy for consistent builds.
* Fixed a logic bug in `ConnectCommand` where the sender IP was only set if the value was present, correcting the conditional.
* Minor formatting and whitespace improvements for readability. [[1]](diffhunk://#diff-9a97ed0393ba9faac76cedf72fa01bc80b77451a4e1f0b44196075ecbe872285R87-R88) [[2]](diffhunk://#diff-9a97ed0393ba9faac76cedf72fa01bc80b77451a4e1f0b44196075ecbe872285R8)

These changes collectively make the codebase safer, more maintainable, and ready for future enhancements involving asynchronous operations.